### PR TITLE
feat: 날짜 변환 함수에서 YYYYMMDD 포맷 문자열 지원하도록 수정

### DIFF
--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -41,7 +41,7 @@
     "lint:fix": "pnpm lint --fix",
     "format": "prettier --check .",
     "format:fix": "prettier --write .",
-    "test": "jest",
+    "test": "jest --verbose",
     "typecheck": "tsc"
   },
   "dependencies": {

--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uxbooster/date",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Date utility library for UX Booster.",
   "author": "Take Corp.",
   "license": "MIT",
@@ -37,7 +37,7 @@
     "lint:fix": "pnpm lint --fix",
     "format": "prettier --check .",
     "format:fix": "prettier --write .",
-    "test": "jest",
+    "test": "jest --verbose",
     "typecheck": "tsc"
   },
   "dependencies": {

--- a/packages/date/src/convertStringToDate.spec.ts
+++ b/packages/date/src/convertStringToDate.spec.ts
@@ -2,9 +2,30 @@ import { describe, it, expect } from '@jest/globals';
 import { convertStringToDate } from './convertStringToDate';
 
 describe('convertStringToDate function', () => {
-  it('converts a string to a Date object', () => {
-    const date = convertStringToDate('2020-01-01');
+  it('converts a string in YYYY-MM-DD format to a Date object', () => {
+    const date = convertStringToDate('2024-01-01');
     expect(date).toBeInstanceOf(Date);
-    expect(date.toISOString()).toBe('2020-01-01T00:00:00.000Z');
+    expect(date.toISOString()).toBe('2024-01-01T00:00:00.000Z'); // 서울 시간으로 변환된 결과
+  });
+
+  it('converts a string in YYYYMMDD format to a Date object', () => {
+    const date = convertStringToDate('20240101');
+    expect(date).toBeInstanceOf(Date);
+    expect(date.toISOString()).toBe('2024-01-01T00:00:00.000Z'); // 서울 시간으로 변환된 결과
+  });
+
+  it('throws an error for non-string and non-Date inputs', () => {
+    expect(() => convertStringToDate(123 as any)).toThrow(
+      '입력값이 문자열 또는 Date 객체가 아닙니다.',
+    );
+    expect(() => convertStringToDate(null as any)).toThrow(
+      '입력값이 문자열 또는 Date 객체가 아닙니다.',
+    );
+  });
+
+  it('converts a string to a Date object in a different timezone', () => {
+    const date = convertStringToDate('2024-01-01', 'America/New_York');
+    expect(date).toBeInstanceOf(Date);
+    expect(date.toISOString()).toBe('2023-12-31T10:00:00.000Z'); // 뉴욕 시간으로 변환된 결과
   });
 });

--- a/packages/date/src/convertStringToDate.ts
+++ b/packages/date/src/convertStringToDate.ts
@@ -9,12 +9,24 @@ const TZ = 'Asia/Seoul';
  * @param date - 변환할 날짜 문자열 또는 Date 객체.
  * @param timezone - 시간대 문자열 (기본값은 'Asia/Seoul'입니다).
  * @returns 변환된 Date 객체.
+ * @throws Error - 유효하지 않은 날짜 문자열인 경우.
  *
  * @example
  * // 2024-01-01T00:00:00+09:00 반환
  * convertStringToDate('2024-01-01');
+ * // 2024-01-01T00:00:00+09:00 반환
+ * convertStringToDate('20240101');
  */
-export const convertStringToDate = (date: string | Date, timezone: string = TZ) => {
-  const parsedDate = typeof date === 'string' ? parseDateString(date) : date;
+export const convertStringToDate = (date: string | Date, timezone: string = TZ): Date => {
+  let parsedDate: Date;
+
+  if (typeof date === 'string') {
+    parsedDate = parseDateString(date);
+  } else if (date instanceof Date) {
+    parsedDate = date;
+  } else {
+    throw new Error('입력값이 문자열 또는 Date 객체가 아닙니다.');
+  }
+
   return utcToZonedTime(parsedDate, timezone);
 };

--- a/packages/date/src/parseDateString.spec.ts
+++ b/packages/date/src/parseDateString.spec.ts
@@ -2,16 +2,27 @@ import { describe, it, expect } from '@jest/globals';
 import { parseDateString } from './parseDateString';
 
 describe('parseDateString function', () => {
-  it('parses a valid date string correctly', () => {
-    const dateString = '2022-05-30T12:00:00.000Z';
-    const date = parseDateString(dateString);
+  it('parses a valid date string in YYYY-MM-DD format', () => {
+    const date = parseDateString('2024-01-01');
     expect(date).toBeInstanceOf(Date);
-    expect(date.toISOString()).toBe(dateString);
+    expect(date.toISOString()).toBe('2024-01-01T00:00:00.000Z');
+  });
+
+  it('parses a valid date string in YYYYMMDD format', () => {
+    const date = parseDateString('20240101');
+    expect(date).toBeInstanceOf(Date);
+    expect(date.toISOString()).toBe('2024-01-01T00:00:00.000Z');
   });
 
   it('throws an error for an invalid date string', () => {
-    expect(() => {
-      parseDateString('invalid date');
-    }).toThrow('Invalid date format');
+    expect(() => parseDateString('invalid-date')).toThrow(
+      'Invalid date format. Expected format: YYYY-MM-DD or YYYYMMDD',
+    );
+  });
+
+  it('throws an error for an empty string', () => {
+    expect(() => parseDateString('')).toThrow(
+      'Invalid date format. Expected format: YYYY-MM-DD or YYYYMMDD',
+    );
   });
 });

--- a/packages/date/src/parseDateString.ts
+++ b/packages/date/src/parseDateString.ts
@@ -5,16 +5,28 @@ import { isValid } from 'date-fns';
  *
  * @param dateString - 구문 분석할 날짜 문자열.
  * @returns 구문 분석된 Date 객체.
- * @throws 날짜 문자열이 유효하지 않은 경우 오류가 발생합니다.
+ * @throws Error - 날짜 문자열이 유효하지 않은 경우 오류가 발생합니다.
  *
  * @example
  * // 2024년 1월 1일을 나타내는 Date 객체 반환
  * parseDateString('2024-01-01');
+ * parseDateString('20240101');
  */
 export const parseDateString = (dateString: string): Date => {
-  const date = new Date(dateString);
-  if (isValid(date)) {
-    return date;
+  let date: Date;
+
+  // YYYYMMDD 형식 처리
+  if (/^\d{8}$/.test(dateString)) {
+    const year = dateString.slice(0, 4);
+    const month = dateString.slice(4, 6);
+    const day = dateString.slice(6, 8);
+    date = new Date(`${year}-${month}-${day}`);
+  } else {
+    date = new Date(dateString);
   }
-  throw new Error('Invalid date format');
+
+  if (!isValid(date)) {
+    throw new Error('Invalid date format. Expected format: YYYY-MM-DD or YYYYMMDD');
+  }
+  return date;
 };

--- a/packages/take-fetch/package.json
+++ b/packages/take-fetch/package.json
@@ -37,7 +37,7 @@
     "lint:fix": "pnpm lint --fix",
     "format": "prettier --check .",
     "format:fix": "prettier --write .",
-    "test": "jest",
+    "test": "jest --verbose",
     "typecheck": "tsc"
   },
   "dependencies": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -37,7 +37,7 @@
     "lint:fix": "pnpm lint --fix",
     "format": "prettier --check .",
     "format:fix": "prettier --write .",
-    "test": "jest",
+    "test": "jest --verbose",
     "typecheck": "tsc"
   },
   "packageManager": "pnpm@9.1.1"

--- a/packages/validators/package.json
+++ b/packages/validators/package.json
@@ -37,7 +37,7 @@
     "lint:fix": "pnpm lint --fix",
     "format": "prettier --check .",
     "format:fix": "prettier --write .",
-    "test": "jest",
+    "test": "jest --verbose",
     "typecheck": "tsc"
   },
   "packageManager": "pnpm@9.1.1"


### PR DESCRIPTION
- convertStringToDate: YYYY-MM-DD와 YYYYMMDD 모두 입력 가능
- parseDateString: YYYYMMDD 입력 문자열의 경우 YYYY-MM-DD로 변환하여 처리
- jest 시 verbose 옵션 추가하여 상세 내역 확인